### PR TITLE
Allow imports inside the slice without index files

### DIFF
--- a/rules/public-api/index.js
+++ b/rules/public-api/index.js
@@ -61,16 +61,12 @@ module.exports = {
 
       /** @duplicate getLayerSliceFromPath - можно убрать функцию и использовать эту */
       const importPathFsdParts = getFsdPartsFromPath(importPath);
-      const currentFilePathFsdParts = getFsdPartsFromPath(currentFilePath);
 
       const isImportFromSameSlice = importSlice === currentFileSlice;
-      const isImportFromSameSegment = importPathFsdParts.segment === currentFilePathFsdParts.segment;
 
       if (isImportFromPublicApi({
-        segmentFiles: importPathFsdParts.segmentFiles,
         segment: importPathFsdParts.segment,
         isImportFromSameSlice,
-        isImportFromSameSegment,
       })) {
         return;
       }

--- a/rules/public-api/index.test.js
+++ b/rules/public-api/index.test.js
@@ -167,6 +167,11 @@ ruleTester.run('public-api', rule, {
       filename: '',
       code: `export const foo = () => () => {};`,
     },
+    {
+      /* should allow segments without index files */
+      filename: 'src/features/foo/index.ts',
+      code: `import { bar } from "./ui/bar";`,
+    },
   ],
 
   invalid: [
@@ -306,28 +311,6 @@ ruleTester.run('public-api', rule, {
           'assets',
           "import { Bar } from '@/features/group-folder/sub-group-folder/sub-sub-group/bar';",
           '@/features/group-folder/sub-group-folder/sub-sub-group/bar',
-        ),
-      ],
-    },
-    {
-      code: "import { useFoo } from '../model/use-foo';",
-      filename: '/Users/test-user/repository/src/features/foo/ui/index.vue',
-      errors: [
-        makeErrorWithSuggestion(
-          'use-foo',
-          "import { useFoo } from '../model';",
-          '../model',
-        ),
-      ],
-    },
-    {
-      code: "export { useRoom } from './lib/useRoom';",
-      filename: '/Users/macbook/Projects/the-rooms/src/entities/room/index.ts',
-      errors: [
-        makeErrorWithSuggestion(
-          'useRoom',
-          "export { useRoom } from './lib';",
-          './lib',
         ),
       ],
     },

--- a/rules/public-api/model/is-import-from-public-api.js
+++ b/rules/public-api/model/is-import-from-public-api.js
@@ -1,20 +1,10 @@
-const isImportFromIndexFile = (segmentFiles) => {
-  return /^index\.\w+/i.test(segmentFiles);
-};
-
 module.exports.isImportFromPublicApi = ({
-  segmentFiles,
   segment,
   isImportFromSameSlice,
-  isImportFromSameSegment,
 }) => {
   if (!isImportFromSameSlice) {
     return segment === '';
   }
 
-  if (isImportFromSameSegment) {
-    return true;
-  } else {
-    return isImportFromIndexFile(segmentFiles) || segmentFiles === '';
-  }
+  return true;
 };


### PR DESCRIPTION
Closes #5 

## Caveats

Some people might want to enforce index files in segments as well, but since the methodology declares them as optional, this enforcement too should be optional. I haven't added an option to enforce it, so maybe it can be a future improvement.